### PR TITLE
Require Node 14 explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ yarn build
 yarn test
 ```
 
+Node 14 is required to work on this repository, though will not be required for
+the eventual bundled outputs prepared for other systems.
+
 ## Using the schemas
 
 TBD

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "license": "MPL-2.0",
   "engines": {
-    "node": "14"
+    "node": "^14.0.0"
   },
   "scripts": {
     "build": "npm-run-all -s build:*",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "rapid-experiments-shared",
   "version": "0.0.1",
   "license": "MPL-2.0",
+  "engines": {
+    "node": "14"
+  },
   "scripts": {
     "build": "npm-run-all -s build:*",
     "build:json-schema": "./bin/build-schemas.ts",


### PR DESCRIPTION
```
❯ node --version
v12.16.2

❯ yarn
yarn install v1.22.4
[1/5] Validating package.json...
error rapid-experiments-shared@0.0.1: The engine "node" is incompatible with
this module. Expected version "14". Got "12.16.2"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about
this command.
```