### PR TITLE
Make unhandled promise errors in build and tests fatal

### DIFF
--- a/bin/build-schemas.ts
+++ b/bin/build-schemas.ts
@@ -95,4 +95,9 @@ async function* walk(
   }
 }
 
+process.on("unhandledRejection", (reason, promise) => {
+  console.log("Unhandled Reject at:", promise, "reason:", reason);
+  process.exit(1);
+});
+
 main();

--- a/test/normandy-arguments.ts
+++ b/test/normandy-arguments.ts
@@ -48,4 +48,9 @@ function convertActionNameToTypeName(actionName: string): string {
   return typeName + "Arguments";
 }
 
+process.on("unhandledRejection", (reason, promise) => {
+  console.log("Unhandled promise rejection:", reason);
+  process.exit(1);
+});
+
 main();

--- a/test/normandy-arguments.ts
+++ b/test/normandy-arguments.ts
@@ -12,7 +12,7 @@ async function main() {
   for await (const recipe of fetchEnabledRecipes()) {
     const revision = recipe.approved_revision ?? recipe.latest_revision;
     const typeName = convertActionNameToTypeName(revision.action.name);
-    const schema = await fs.readFile(`./dist/normandy/${typeName}.json`);
+    const schema = await fs.readFile(`./schemas/normandy/${typeName}.json`);
 
     if (!ajv.validate(schema, revision.arguments)) {
       throw new Error(


### PR DESCRIPTION
It is expected that this will cause CI to fail at first, since there are unfixed errors. Those should be fixed with the second commit.

Fixes #4