### PR TITLE
Automatically generate type guards

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,12 +10,12 @@ jobs:
       - node/with-cache:
           steps:
             - run: yarn install
-            - run: yarn build
-            - run: yarn test
-            - run: yarn lint
+            - run: make build
+            - run: make test
+            - run: make lint
       - run:
           name: Preparing artifacts
-          command: yarn artifact
+          command: make artifact
       - store_artifacts:
           path: ./artifacts
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - checkout
       - node/with-cache:
           steps:
-            - run: yarn install
+            - run: make install
             - run: make build
             - run: make test
             - run: make lint

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+dist/
+schemas/

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ schemas/
 artifacts/
 src/typeGuardHelpers.ts
 .tsc-last-run
+.yarn-last-run

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ dist/
 node_modules/
 schemas/
 artifacts/
+src/typeGuardHelpers.ts
+.tsc-last-run

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+# Schemas are anything we can find in the schema directory, plus the directory itself
+TYPES ::= $(shell find ./types -name '*.ts')
+TS_SRC ::= $(shell find ./src -name '*.ts')
+TSC_STAMP := ./.tsc-last-run
+
+.PHONY: build clean test lint
+
+build: $(TSC_STAMP) $(SCHEMAS) src/typeGuardHelpers.ts
+
+clean:
+	rm -rf dist schemas
+
+test: build
+	./test/normandy-arguments.ts
+
+artifact: build
+	./bin/pack-artifact.sh
+
+lint:
+	eslint --ignore dist .
+
+$(TSC_STAMP): src/typeGuardHelpers.ts $(TS_SRC) $(TYPES)
+	tsc
+	@touch .tsc-last-run
+
+$(SCHEMAS): $(shell find ./types -name '*.ts')
+	./bin/build-schemas.ts
+
+src/typeGuardHelpers.ts: $(SCHEMAS) bin/generate-type-guards.ts
+	./bin/generate-type-guards.ts

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,9 @@ YARN_STAMP := ./.yarn-last-run
 
 export PATH := node_modules/.bin:$(PATH)
 
-.PHONY: install  build clean test lint
+.PHONY: install build clean test lint default
+
+default: build
 
 install: $(YARN_STAMP)
 
@@ -18,7 +20,7 @@ $(YARN_STAMP): package.json yarn.lock
 	@touch $(YARN_STAMP)
 
 clean:
-	rm -rf dist schemas $(TSC_STAMP) node_modules
+	rm -rf dist $(SCHEMAS) $(TSC_STAMP) $(YARN_STAMP) node_modules
 
 test: build
 	./test/normandy-arguments.ts
@@ -36,5 +38,5 @@ $(TSC_STAMP): src/typeGuardHelpers.ts $(TS_SRC) $(TYPES) $(YARN_STAMP)
 $(SCHEMAS): $(shell find ./types -name '*.ts') $(YARN_STAMP)
 	./bin/build-schemas.ts
 
-src/typeGuardHelpers.ts: $(SCHEMAS) bin/generate-type-guards.ts
+src/typeGuardHelpers.ts: $(YARN_STAMP) $(SCHEMAS) bin/generate-type-guards.ts
 	./bin/generate-type-guards.ts

--- a/Makefile
+++ b/Makefile
@@ -28,8 +28,8 @@ test: build
 artifact: build
 	./bin/pack-artifact.sh
 
-lint: $(YARN_STAMP)
-	eslint --ignore dist .
+lint: $(YARN_STAMP) build
+	eslint .
 
 $(TSC_STAMP): src/typeGuardHelpers.ts $(TS_SRC) $(TYPES) $(YARN_STAMP)
 	tsc

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ TYPES ::= $(shell find ./types -name '*.ts')
 TS_SRC ::= $(shell find ./src -name '*.ts')
 TSC_STAMP := ./.tsc-last-run
 
+export PATH := node_modules/.bin:$(PATH)
+
 .PHONY: build clean test lint
 
 build: $(TSC_STAMP) $(SCHEMAS) src/typeGuardHelpers.ts

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ $(TSC_STAMP): src/typeGuardHelpers.ts $(TS_SRC) $(TYPES) $(YARN_STAMP)
 	tsc
 	@touch $(TSC_STAMP)
 
-$(SCHEMAS): $(shell find ./types -name '*.ts') $(YARN_STAMP)
+$(SCHEMAS): $(shell find ./types -name '*.ts') $(YARN_STAMP) bin/build-schemas.ts
 	./bin/build-schemas.ts
 
 src/typeGuardHelpers.ts: $(YARN_STAMP) $(SCHEMAS) bin/generate-type-guards.ts

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,24 @@
 # Schemas are anything we can find in the schema directory, plus the directory itself
-TYPES ::= $(shell find ./types -name '*.ts')
-TS_SRC ::= $(shell find ./src -name '*.ts')
+SCHEMAS := schemas $(shell test -d schemas && find schemas -name '*.json')
+TYPES := $(shell find ./types -name '*.ts')
+TS_SRC := $(shell find ./src -name '*.ts')
 TSC_STAMP := ./.tsc-last-run
+YARN_STAMP := ./.yarn-last-run
 
 export PATH := node_modules/.bin:$(PATH)
 
-.PHONY: build clean test lint
+.PHONY: install  build clean test lint
 
-build: $(TSC_STAMP) $(SCHEMAS) src/typeGuardHelpers.ts
+install: $(YARN_STAMP)
+
+build: $(TSC_STAMP) $(SCHEMAS) src/typeGuardHelpers.ts $(YARN_STAMP)
+
+$(YARN_STAMP): package.json yarn.lock
+	yarn install
+	@touch $(YARN_STAMP)
 
 clean:
-	rm -rf dist schemas
+	rm -rf dist schemas $(TSC_STAMP) node_modules
 
 test: build
 	./test/normandy-arguments.ts
@@ -18,14 +26,14 @@ test: build
 artifact: build
 	./bin/pack-artifact.sh
 
-lint:
+lint: $(YARN_STAMP)
 	eslint --ignore dist .
 
-$(TSC_STAMP): src/typeGuardHelpers.ts $(TS_SRC) $(TYPES)
+$(TSC_STAMP): src/typeGuardHelpers.ts $(TS_SRC) $(TYPES) $(YARN_STAMP)
 	tsc
-	@touch .tsc-last-run
+	@touch $(TSC_STAMP)
 
-$(SCHEMAS): $(shell find ./types -name '*.ts')
+$(SCHEMAS): $(shell find ./types -name '*.ts') $(YARN_STAMP)
 	./bin/build-schemas.ts
 
 src/typeGuardHelpers.ts: $(SCHEMAS) bin/generate-type-guards.ts

--- a/README.md
+++ b/README.md
@@ -10,12 +10,18 @@ shared.
 
 ## Working on this repo
 
-Common tasks are defined as Yarn scripts.
+Use Yarn to install dependencies:
 
 ```shell
 yarn install
-yarn build
-yarn test
+```
+
+Common tasks are defined as Make targets:
+
+```shell
+make lint
+make build
+make test
 ```
 
 Node 14 is required to work on this repository, though will not be required for

--- a/bin/build-schemas.ts
+++ b/bin/build-schemas.ts
@@ -34,6 +34,7 @@ async function main() {
     if (!schema.definitions) {
       continue;
     }
+
     for (const type of Object.keys(schema.definitions)) {
       const typeSchema = generator.createSchema(type);
       const dirPath = `./schemas/${fileNameWithoutExtension}`;

--- a/bin/build-schemas.ts
+++ b/bin/build-schemas.ts
@@ -1,8 +1,9 @@
 #!/usr/bin/env ts-node-script
-import { promises as fs, Dirent } from "fs";
+import { promises as fs } from "fs";
 import * as path from "path";
 import * as tsj from "ts-json-schema-generator";
-import * as tjs from "typescript-json-schema";
+
+import { walk } from "../src/utils";
 
 async function main() {
   const config: tsj.Config = {
@@ -21,20 +22,12 @@ async function main() {
     }
   }
 
-  const program = tjs.programFromConfig("./tsconfig.json");
-
+  // Make a JSON schema file for every type
   for await (const { path: srcFilePath } of walk("./types/")) {
-    // const schema = tjs.generateSchema(program, "*", {
-    //   excludePrivate: true,
-    //   include: [srcFilePath],
-    //   topRef: true,
-    //   defaultProps: true,
-    // });
-
-    // const { name: fileNameWithoutExtension } = path.parse(srcFilePath);
-    // const outPath = `schemas/${fileNameWithoutExtension}.json`;
-    // await fs.writeFile(outPath, JSON.stringify(schema, null, 2));
-
+    // process only .ts files and not .d.ts files.
+    if (!srcFilePath.endsWith(".ts") || srcFilePath.endsWith(".d.ts")) {
+      continue;
+    }
     const generator = tsj.createGenerator({ ...config, path: srcFilePath });
     const schema = generator.createSchema();
     const { name: fileNameWithoutExtension } = path.parse(srcFilePath);
@@ -46,49 +39,7 @@ async function main() {
       const dirPath = `./schemas/${fileNameWithoutExtension}`;
       await fs.mkdir(dirPath, { recursive: true });
       const outPath = `${dirPath}/${type}.json`;
-      console.info(`${srcFilePath}::${type} -> ${outPath}`);
       await fs.writeFile(outPath, JSON.stringify(typeSchema, null, 2));
-    }
-  }
-}
-
-interface WalkOptions {
-  includeDirs?: "only" | "include" | "exclude";
-}
-
-interface WalkDirEntry extends Dirent {
-  path: string;
-}
-
-/**
- * Iterate through a directory and all its descendants.
- *
- * Contents are iterated in a depth-first order, i.e. all contents of a
- * directory will be recursively yielded before the directory.
- *
- * The top level directory will not be yielded.
- *
- * @param dir
- *   The path of the directory to walk
- * @param opts.includeDirs
- *   Controls how directory entries are included in the output.
- */
-async function* walk(
-  dir: string,
-  opts: WalkOptions = { includeDirs: "exclude" }
-): AsyncGenerator<WalkDirEntry, void> {
-  for await (const entry of await fs.opendir(dir)) {
-    const rv = entry as WalkDirEntry;
-    rv.path = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      yield* walk(rv.path, opts);
-      if (opts.includeDirs != "exclude") {
-        yield rv;
-      }
-    } else if (entry.isFile()) {
-      if (opts.includeDirs != "only") {
-        yield rv;
-      }
     }
   }
 }

--- a/bin/generate-type-guards.ts
+++ b/bin/generate-type-guards.ts
@@ -1,0 +1,156 @@
+#!/usr/bin/env ts-node-script
+import ts from "typescript";
+import { walk } from "../src/utils";
+import path from "path";
+import { promises as fs } from "fs";
+
+/** Build a type guard function for the type specified */
+function makeTypeGuard(path: Array<string>, typeName: string): ts.Node {
+  const functionName = ts.createIdentifier(
+    path.concat([`is${typeName}`]).join("_")
+  );
+  const paramName = ts.createIdentifier("obj");
+  const parameter = ts.createParameter(
+    /* decorators */ undefined,
+    /* modifiers */ undefined,
+    /* dotDotDotToken */ undefined,
+    paramName,
+    /* questionToken */ undefined,
+    ts.createTypeReferenceNode("object", /* typeArguments */ [])
+  );
+
+  const assertedTypeNode = ts.createTypeReferenceNode(typeName, []);
+  const returnType = ts.createTypePredicateNode(paramName, assertedTypeNode);
+
+  const funcCall = ts.createCall(
+    ts.createIdentifier("checkSchema"),
+    /* typeArguments */ [],
+    [ts.createStringLiteral(typeName), paramName]
+  );
+  const returnNode = ts.createReturn(funcCall);
+
+  return ts.createFunctionDeclaration(
+    /* decorators */ undefined, // decorators
+    [ts.createToken(ts.SyntaxKind.ExportKeyword)],
+    /* asteriskToken */ undefined,
+    functionName,
+    /* typeParameters */ [],
+    [parameter],
+    returnType,
+    ts.createBlock([returnNode], /* multiline */ true)
+  );
+}
+
+async function makeImports(
+  typesNeeded: Array<{ file: string; type: string }>
+): Promise<Array<ts.Node>> {
+  const typeGuardImport = ts.createImportDeclaration(
+    /* decorators */ [],
+    /* modifiers */ [],
+    ts.createImportClause(
+      undefined,
+      ts.createNamedImports([
+        ts.createImportSpecifier(undefined, ts.createIdentifier("checkSchema")),
+      ]),
+      undefined
+    ),
+    ts.createStringLiteral("./typeGuards")
+  );
+
+  // Create a mapping that groups imports by the file they come from
+  const typesByFile: { [file: string]: Array<string> } = {};
+  const typesSeen = new Set();
+  for (const entry of typesNeeded) {
+    if (typesSeen.has(entry.type)) {
+      console.warn(`Warning: duplicate type ${entry.type}`);
+      continue;
+    }
+    if (!typesByFile[entry.file]) {
+      typesByFile[entry.file] = [];
+    }
+    typesByFile[entry.file].push(entry.type);
+    typesSeen.add(entry.type);
+  }
+
+  // Generate one import per file that imports everything needed from that file
+  const neededTypeImports = Object.entries(
+    typesByFile
+  ).map(([file, types]: [string, Array<string>]) =>
+    ts.createImportDeclaration(
+      /* decorators */ [],
+      /* modifiers */ [],
+      ts.createImportClause(
+        /** No default import */ undefined,
+        ts.createNamedImports(
+          types.map((type) =>
+            ts.createImportSpecifier(undefined, ts.createIdentifier(type))
+          )
+        ),
+        /* isTypeOnly */ true
+      ),
+      ts.createStringLiteral(`../types/${file}`)
+    )
+  );
+
+  return [typeGuardImport].concat(neededTypeImports);
+}
+
+async function makeTypeScriptSource() {
+  const resultFile = ts.createSourceFile(
+    "src/typeGuardHelpers.ts",
+    /* sourceText */ "",
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ false,
+    ts.ScriptKind.TS
+  );
+  const printer = ts.createPrinter({ newLine: ts.NewLineKind.LineFeed });
+  let typeGuardFunctions = "";
+
+  // An import line
+  const importsNeeded = [];
+
+  // Make a type guard for every JSON Schema
+  for await (const { path: srcFilePath } of walk("./schemas/")) {
+    const { name: fileNameWithoutExtension, dir } = path.parse(srcFilePath);
+    const components = dir.split(path.sep);
+    if (components[0] != "schemas") {
+      throw new Error(
+        `Expected path to start with schemas, got ${srcFilePath}`
+      );
+    }
+    if (components.length > 2) {
+      throw new Error("Can only handle a single level of nesting in schemas");
+    }
+    importsNeeded.push({
+      file: components.slice(1).join(path.sep),
+      type: fileNameWithoutExtension,
+    });
+
+    typeGuardFunctions += printer.printNode(
+      ts.EmitHint.Unspecified,
+      makeTypeGuard(components.slice(1), fileNameWithoutExtension),
+      resultFile
+    );
+    typeGuardFunctions += "\n\n";
+  }
+
+  const importLines = (await makeImports(importsNeeded))
+    .map((node) => printer.printNode(ts.EmitHint.Unspecified, node, resultFile))
+    .join("\n");
+
+  const eslintFix = "/* eslint-disable @typescript-eslint/ban-types */";
+
+  return [eslintFix, importLines, typeGuardFunctions].join("\n\n");
+}
+
+async function main() {
+  const typeScriptSource = await makeTypeScriptSource();
+  await fs.writeFile("./src/typeGuardHelpers.ts", typeScriptSource);
+}
+
+process.on("unhandledRejection", (reason, promise) => {
+  console.error("Unhandled Reject at:", promise, "reason:", reason);
+  process.exit(1);
+});
+
+main();

--- a/package.json
+++ b/package.json
@@ -6,20 +6,20 @@
     "node": "^14.0.0"
   },
   "scripts": {
-    "build": "npm-run-all -s build:*",
-    "build:json-schema": "./bin/build-schemas.ts",
-    "artifact": "./bin/pack-artifact.sh",
-    "lint": "eslint .",
-    "test": "npm-run-all -s test:*",
-    "test:normandy-arguments": "./test/normandy-arguments.ts"
+    "build": "make build",
+    "artifact": "make artifact",
+    "lint": "make lint",
+    "test": "make test"
   },
-  "dependencies": {},
+  "types": "index.d.ts",
+  "dependencies": {
+    "ajv": "^6.12.2"
+  },
   "devDependencies": {
     "@types/node": "^14.0.3",
     "@types/node-fetch": "^2.5.7",
     "@typescript-eslint/eslint-plugin": "^3.0.2",
     "@typescript-eslint/parser": "^3.0.2",
-    "ajv": "^6.12.2",
     "eslint": "^7.1.0",
     "node-fetch": "^2.6.0",
     "npm-run-all": "^4.1.5",

--- a/src/typeGuards.ts
+++ b/src/typeGuards.ts
@@ -1,0 +1,29 @@
+import fs from "fs";
+export * from "./typeGuardHelpers";
+
+import Ajv from "ajv";
+import { isBoolean } from "util";
+
+export function checkSchema(
+  schemaName: string,
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  obj: object
+): boolean {
+  const ajv = new Ajv();
+
+  const schemaText = fs.readFileSync(`schemas/${schemaName}.json`, {
+    encoding: "utf8",
+  });
+  const schema = JSON.parse(schemaText);
+
+  const validationResult = ajv.validate(schema, obj);
+  if (!isBoolean(validationResult)) {
+    throw new Error(
+      "Schema validation cannot be async, but AJV returned an async result"
+    );
+  }
+  if (!validationResult) {
+    console.error(ajv.errors);
+  }
+  return validationResult;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,43 @@
+import path from "path";
+import { promises as fs, Dirent } from "fs";
+
+interface WalkOptions {
+  includeDirs?: "only" | "include" | "exclude";
+}
+
+interface WalkDirEntry extends Dirent {
+  path: string;
+}
+
+/**
+ * Iterate through a directory and all its descendants.
+ *
+ * Contents are iterated in a depth-first order, i.e. all contents of a
+ * directory will be recursively yielded before the directory.
+ *
+ * The top level directory will not be yielded.
+ *
+ * @param dir
+ *   The path of the directory to walk
+ * @param opts.includeDirs
+ *   Controls how directory entries are included in the output.
+ */
+export async function* walk(
+  dir: string,
+  opts: WalkOptions = { includeDirs: "exclude" }
+): AsyncGenerator<WalkDirEntry, void> {
+  for await (const entry of await fs.opendir(dir)) {
+    const rv = entry as WalkDirEntry;
+    rv.path = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walk(rv.path, opts);
+      if (opts.includeDirs != "exclude") {
+        yield rv;
+      }
+    } else if (entry.isFile()) {
+      if (opts.includeDirs != "only") {
+        yield rv;
+      }
+    }
+  }
+}

--- a/test/normandy-arguments.ts
+++ b/test/normandy-arguments.ts
@@ -18,8 +18,6 @@ async function main() {
       throw new Error(
         `Recipe ${recipe.id} does not have valid arguments: ${ajv.errors}`
       );
-    } else {
-      console.log(`Recipe ${recipe.id} arguments are valid ${typeName}`);
     }
   }
 }
@@ -48,7 +46,7 @@ function convertActionNameToTypeName(actionName: string): string {
   return typeName + "Arguments";
 }
 
-process.on("unhandledRejection", (reason, promise) => {
+process.on("unhandledRejection", (reason) => {
   console.log("Unhandled promise rejection:", reason);
   process.exit(1);
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,13 @@
 {
-  "include": ["src", "arguments.ts"],
+  "include": ["types", "src"],
   "exclude": ["node_modules"],
   "compilerOptions": {
-    "noEmit": true,
+    "outDir": "dist",
+    "declaration": true,
+    "lib": ["ES2018"],
     "module": "CommonJS",
     "strict": true,
-    "target": "es2020",
+    "target": "ES2018",
     "esModuleInterop": true
   }
 }

--- a/types/normandy.ts
+++ b/types/normandy.ts
@@ -1,5 +1,3 @@
-import { CfrMessage } from "./messaging";
-
 /** A Normandy recipe */
 export interface NormandyRecipe {
   /** The primary key of the recipe */
@@ -319,7 +317,7 @@ interface MessagingExperimentBranch {
   groups: Array<string>;
 
   /** Message content  */
-  value: CfrMessage | AddonRollbackArguments;
+  value: Record<string, unknown>;
 }
 
 /** Enroll a user in an add-on experiment, with managed branches */


### PR DESCRIPTION
In working on this, I ended up needing to have dependencies between build jobs, so I switched to using Make for the task running.

This works from a shell in this project, but won't currently work on another project. That's because it loads the schemas via synchronous filesystem access with some pretty inflexible paths. I plan to do more thinking to figure out how to best do this in a more useful way.

Fixes #7